### PR TITLE
feat: permission based feature access

### DIFF
--- a/edx_sysadmin/git_import.py
+++ b/edx_sysadmin/git_import.py
@@ -18,8 +18,10 @@ from django.utils.translation import ugettext_lazy as _
 from opaque_keys.edx.locator import CourseLocator
 from six import StringIO
 
-from edx_sysadmin.models import CourseImportLog
 from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
+
+from edx_sysadmin.models import CourseImportLog
+
 
 log = logging.getLogger(__name__)
 

--- a/edx_sysadmin/management/commands/git_add_course.py
+++ b/edx_sysadmin/management/commands/git_add_course.py
@@ -7,9 +7,11 @@ import logging
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 
-from edx_sysadmin import git_import
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.xml import XMLModuleStore
+
+from edx_sysadmin import git_import
+
 
 log = logging.getLogger(__name__)
 

--- a/edx_sysadmin/management/commands/tests/test_git_add_course.py
+++ b/edx_sysadmin/management/commands/tests/test_git_add_course.py
@@ -1,21 +1,24 @@
 """
 Provide tests for git_add_course management command.
 """
-
-
 import logging
 import os
 import shutil
 import subprocess
 from uuid import uuid4
 
-import six
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test.utils import override_settings
 from opaque_keys.edx.keys import CourseKey
+import six
 from six import StringIO
+
+from xmodule.modulestore import ModuleStoreEnum
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
+from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
 
 from edx_sysadmin import git_import
 from edx_sysadmin.git_import import (
@@ -26,10 +29,7 @@ from edx_sysadmin.git_import import (
     GitImportErrorRemoteBranchMissing,
     GitImportErrorUrlBad,
 )
-from xmodule.modulestore import ModuleStoreEnum
-from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
-from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
+
 
 TEST_MONGODB_LOG = {
     "host": MONGO_HOST,

--- a/edx_sysadmin/static/edx_sysadmin/css/style.css
+++ b/edx_sysadmin/static/edx_sysadmin/css/style.css
@@ -99,6 +99,10 @@ textarea {
 	margin-left: 10px;
 }
 
+.instructor-nav a.active {
+	text-decoration: underline;
+}
+
 .disclaimer {
 	line-height: 1.5rem;
 	text-align: center;

--- a/edx_sysadmin/templates/edx_sysadmin/base.html
+++ b/edx_sysadmin/templates/edx_sysadmin/base.html
@@ -13,10 +13,18 @@
             <h1 class="main-heading">{% trans "Sysadmin Dashboard" %}</h1>
             <hr />
             <h2 class="instructor-nav">
-                <a href="{% url 'sysadmin:users' %}">{% trans "Users" %}</a>
-                <a href="{% url 'sysadmin:courses' %}"> {% trans "Courses" %} </a>
-                <a href="{% url 'sysadmin:gitimport' %}"> {% trans "Git Import" %} </a>
-                <a href="{% url 'sysadmin:gitlogs' %}"> {% trans "Git Logs" %} </a>
+                {% if show_users_tab %}
+                    <a href="{% url 'sysadmin:users' %}" class="{% if is_users_tab %} active {% endif %}">{% trans "Users" %}</a>
+                {% endif %}
+                {% if show_courses_tab %}
+                    <a href="{% url 'sysadmin:courses' %}" class="{% if is_courses_tab %} active {% endif %}"> {% trans "Courses" %} </a>
+                {% endif %}
+                {% if show_git_import_tab %}
+                    <a href="{% url 'sysadmin:gitimport' %}" class="{% if is_git_import_tab %} active {% endif %}"> {% trans "Git Import" %} </a>
+                {% endif %}
+                {% if show_git_logs_tab %}
+                    <a href="{% url 'sysadmin:gitlogs' %}" class="{% if is_git_logs_tab %} active {% endif %}"> {% trans "Git Logs" %} </a>
+                {% endif %}
             </h2>
             <hr />
             {% block panel %}

--- a/edx_sysadmin/urls.py
+++ b/edx_sysadmin/urls.py
@@ -4,8 +4,8 @@ URLs for edx_sysadmin.
 from django.conf.urls import url
 
 from edx_sysadmin.views import (
+    SysadminDashboardRedirectionView,
     CoursesPanel,
-    SysadminDashboardView,
     UsersPanel,
     GitImport,
     GitLogs,
@@ -15,7 +15,7 @@ app_name = "sysadmin"
 
 
 urlpatterns = [
-    url("^$", SysadminDashboardView.as_view(), name="sysadmin"),
+    url("^$", SysadminDashboardRedirectionView.as_view(), name="sysadmin"),
     url(r"^courses/?$", CoursesPanel.as_view(), name="courses"),
     url(r"^gitimport/$", GitImport.as_view(), name="gitimport"),
     url(r"^gitlogs/?$", GitLogs.as_view(), name="gitlogs"),

--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-error
 """
 Utility function defined here.
 """
@@ -16,6 +15,9 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 
 from common.djangoapps.student.models import UserProfile
+from common.djangoapps.student.roles import (
+    CourseInstructorRole,
+)
 from common.djangoapps.util.password_policy_validators import normalize_password
 from openedx.core.djangoapps.user_authn.toggles import (
     is_require_third_party_auth_enabled,
@@ -334,9 +336,14 @@ def user_has_access_to_sysadmin(user):
     :param user: User object of currently loggedin user
     :return boolean: True if user has access to syadmin else False
     """
-    # TODO: Give access to Course Admins
-    if user and user.is_staff:
+    if (
+        user_has_access_to_users_panel(user)
+        or user_has_access_to_courses_panel(user)
+        or user_has_access_to_git_logs_panel(user)
+        or user_has_access_to_git_import_panel(user)
+    ):
         return True
+    return False
 
 
 def show_sysadmin_dashboard(user):
@@ -345,3 +352,50 @@ def show_sysadmin_dashboard(user):
     :return boolean: True if all requirements are fulfilled else False
     """
     return user_has_access_to_sysadmin(user)
+
+
+def user_has_access_to_users_panel(user):
+    """
+    Checks if user has access to "Users" panel or not
+    :param user: User object of currently loggedin user
+    :return boolean: True if user has access to "Users" panel else False
+    """
+    if user and user.is_staff:
+        return True
+    return False
+
+
+def user_has_access_to_courses_panel(user):
+    """
+    Checks if user has access to "Courses" panel or not
+    :param user: User object of currently loggedin user
+    :return boolean: True if user has access to "Courses" panel else False
+    """
+    if user and user.is_staff:
+        return True
+    return False
+
+
+def user_has_access_to_git_logs_panel(user):
+    """
+    Checks if user has access to "Git Logs" panel or not
+    :param user: User object of currently loggedin user
+    :return boolean: True if user has access to "Git Logs" panel else False
+    """
+    if user and (
+        user.is_staff
+        or user.courseaccessrole_set.filter(role=CourseInstructorRole.ROLE).exists()
+    ):
+        return True
+    return False
+
+
+def user_has_access_to_git_import_panel(user):
+    """
+    Checks if user has access to "Git Import" panel or not
+    :param user: User object of currently loggedin user
+    :return boolean: True if user has access to "Git Import" panel else False
+    """
+    if user and user.is_staff:
+        return True
+    return False


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots

#### What are the relevant tickets?
https://github.com/mitodl/edx-sysadmin/issues/16

#### What's this PR do?
It adds permission-based feature access in which global staff user (is_staff) has access to all the features of sysadmin while course-admins (instructors) are bound to see only the git-logs of their courses.

We were trying to allow Course-Admins to update their courses from git using the Git-Import feature while restricting them from creating a new course using the same feature but that's not possible because until the course repo is fetched and the course is created we can't tell if the user has entered a new git repo link or updated an existing course. Thus we have to restrict Course-Admins from the whole Git-Import feature.

#### How should this be manually tested?
Try to access sysadmin with a course-admin user and an is_staff user and observe if they have the appropriate rights.

#### Screenshots (if appropriate)
Staff User (is_staff) view:
![image](https://user-images.githubusercontent.com/42243411/114866002-784c6200-9e0c-11eb-92b7-b9a1046d909f.png)

Course Admin view:
![image](https://user-images.githubusercontent.com/42243411/114866156-a92c9700-9e0c-11eb-9808-7f0b34ce7a30.png)
