### PR TITLE
Clear User fields on success

### DIFF
--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -315,15 +315,15 @@ def get_fields_and_default_values_map():
         },
         "mailing_address": {
             "field_type": forms.CharField,
-            "default_value": "This is the default Mailing Address",
+            "default_value": "",
         },
         "goals": {
             "field_type": forms.CharField,
-            "default_value": "This is the default Goal",
+            "default_value": "",
         },
-        "honor_code": {"field_type": forms.BooleanField, "default_value": True},
-        "terms_of_service": {"field_type": forms.BooleanField, "default_value": True},
-        "city": {"field_type": forms.CharField, "default_value": "Kabul"},
+        "honor_code": {"field_type": forms.BooleanField, "default_value": False},
+        "terms_of_service": {"field_type": forms.BooleanField, "default_value": False},
+        "city": {"field_type": forms.CharField, "default_value": ""},
         "country": {
             "field_type": forms.TypedChoiceField,
             "choices": get_country_choices(),

--- a/edx_sysadmin/views.py
+++ b/edx_sysadmin/views.py
@@ -214,6 +214,10 @@ class UsersPanel(SysadminDashboardBaseView):
             context.update(
                 create_user_account(form.cleaned_data, request.build_absolute_uri)
             )
+            if context.get("success_message"):
+                success_message = context.get("success_message")
+                context = self.get_context_data()
+                context["success_message"] = success_message
         else:
             context["error_message"] = _(
                 "Unable to create new account due to invalid data"

--- a/edx_sysadmin/views.py
+++ b/edx_sysadmin/views.py
@@ -209,7 +209,6 @@ class UsersPanel(SysadminDashboardBaseView):
         extra_fields = get_registration_required_extra_fields_with_values()
         form = UserRegistrationForm(request.POST, extra_fields=extra_fields)
         context = self.get_context_data(initial_data=request.POST, **kwargs)
-
         if form.is_valid():
             context.update(
                 create_user_account(form.cleaned_data, request.build_absolute_uri)


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/edx-sysadmin/issues/34

#### What's this PR do?
Clears User creation form on the successful account creation.

#### How should this be manually tested?
Create user accounts through the User's tab in sysadmin. the fields should be cleared on successful account creation.

#### Note
The fields which have choices in them will not be cleared (like country, gender, etc) as the first element in choices gets picked automatically. 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42243411/119464183-ecf3b400-bd5b-11eb-8c66-e95411404432.png)

