### PR TITLE
fix: standardising the messages design with edX

### DIFF
--- a/edx_sysadmin/static/edx_sysadmin/css/style.css
+++ b/edx_sysadmin/static/edx_sysadmin/css/style.css
@@ -1,13 +1,16 @@
 /*
 Sysadmin Stylesheet
 */
-
+:root{
+    --brand-red: #cb0712;
+    --brand-green: #008000;
+}
 .main-heading {
     font-size: 30px;
 }
 
 .warning-alert h5 {
-    color: red;
+    color: var(--brand-red);
     text-align: left;
     text-decoration: underline;
     margin-bottom: 10px;
@@ -62,30 +65,28 @@ textarea {
 }
 
 .error {
-    color: red;
+    color: var(--brand-red);
 }
 
 .success {
-    color: green;
+    color: var(--brand-green);
 }
 
 .error_message {
-	background-color: #FFBABA;
+    color: var(--brand-red);
 	border-radius: 10px;
-	color: black;
 	margin-bottom: 20px;
 	margin-top: 10px;
 	padding: 20px;
 }
 
 .errorlist {
-    color: red;
+    color: var(--brand-red);
 }
 
 .success_message {
-	background-color: #DFF2BF;
 	border-radius: 10px;
-	color: black;
+	color: var(--brand-green);
 	margin-bottom: 20px;
 	margin-top: 10px;
 	padding: 20px;

--- a/edx_sysadmin/templates/edx_sysadmin/users.html
+++ b/edx_sysadmin/templates/edx_sysadmin/users.html
@@ -13,6 +13,7 @@
     <h3>{% trans "Register Users" %}</h3><br/>
 
     {% if error_message %}
+
 		<div class="error_message">{{error_message|safe}}</div>
     {% endif %}
     {% if success_message %}

--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -105,7 +105,7 @@ def get_registration_required_extra_fields_with_values():
 def is_registration_api_functional():
     """
     Checks if User Registration API "/user_api/v1/account/registration/" is functional or not
-    depending upon two environemnt variables "settings.FEATURES['ALLOW_PUBLIC_ACCOUNT_CREATION']"
+    depending upon two environment variables "settings.FEATURES['ALLOW_PUBLIC_ACCOUNT_CREATION']"
     and "settings.ENABLE_REQUIRE_THIRD_PARTY_AUTH"
 
     Arguments:

--- a/edx_sysadmin/views.py
+++ b/edx_sysadmin/views.py
@@ -332,9 +332,10 @@ class GitImport(SysadminDashboardBaseView):
             or gitloc.startswith("https:")
             or gitloc.startswith("git:")
         ):
-            return _(
+            message = HTML("<p style='color:#cb0712'>{0}</p>").format(
                 "The git repo location should end with '.git', " "and be a valid url"
             )
+            return message
 
         return self.import_mongo_course(gitloc, branch)
 
@@ -381,10 +382,10 @@ class GitImport(SysadminDashboardBaseView):
 
         if error_msg:
             msg_header = error_msg
-            color = "red"
+            color = "#cb0712"
         else:
             msg_header = _("Added Course")
-            color = "blue"
+            color = "#008000"
 
         message = HTML("<h4 style='color:{0}'>{1}</h4>").format(color, msg_header)
         message += HTML("<pre>{0}</pre>").format(escape(ret))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#42 

#### What's this PR do?
Standardizes the message design to `edX`.

#### How should this be manually tested?
Check the styling of the error and success messages on sysadmin and make sure they match with edX. Also, more details are added on ticket #42 

#### Where should the reviewer start?
- Install `edx-sysadmin` plugin in your edX instance.
- Open `/sysadmin/users` and create a user with an existing account (You should see existing fields error)
- Open `/sysadmin/users` and create a new user and type mismatched passwords (You should see invalid data error)
(Optional)
- Open `/sysadmin/gitimport` and import a course with the wrong URL format (You should see an error message)
- Following the above steps in the correct way should be showing you the success messages

#### Screenshots (if appropriate)
**Account creation invalid data error Screenshot**
<img width="717" alt="Screenshot 2021-06-08 at 3 00 29 PM" src="https://user-images.githubusercontent.com/34372316/121180165-f9a6fa80-c879-11eb-8bca-13ca9e3eb1c0.png">

**Account creation existing fields data Screenshot**
<img width="1056" alt="Screenshot 2021-06-08 at 3 01 07 PM" src="https://user-images.githubusercontent.com/34372316/121180174-fd3a8180-c879-11eb-9922-df84c24aecb9.png">

**Git Import error Screenshot**
<img width="1268" alt="Screenshot 2021-06-08 at 5 44 40 PM" src="https://user-images.githubusercontent.com/34372316/121187314-5fe34b80-c881-11eb-8d01-4230bac456ba.png">

**User account creation success**
<img width="744" alt="Screenshot 2021-06-08 at 4 58 12 PM" src="https://user-images.githubusercontent.com/34372316/121180928-e34d6e80-c87a-11eb-8d18-5a807cd79508.png">

**Git import success**
<img width="1092" alt="Screenshot 2021-06-08 at 5 01 20 PM" src="https://user-images.githubusercontent.com/34372316/121181194-2c9dbe00-c87b-11eb-85f5-f2e223488922.png">

