### PR TITLE
chore: update tests to run on master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,7 @@ jobs:
           sed -i 's/:cached//g' ./docker-compose-host.yml
           make dev.clone.https
           cd ../edx-platform
-          git remote add mitodl https://github.com/mitodl/edx-platform.git
-          git fetch mitodl
-          git checkout mitodl/arslan/fix-pipeline-import
+          git checkout master
 
       - name: Run tests
         run: |


### PR DESCRIPTION
#### Pre-Flight checklist

None

#### What are the relevant tickets?
None

#### What's this PR do?
- Updates the CI to run tests in the master branch instead of the fix branch that we created earlier.

#### How should this be manually tested?
Just check that the tests are passing


#### Any background context you want to provide?
- In a recent PR(https://github.com/mitodl/edx-sysadmin/pull/57#discussion_r758408158) we saw that the tests were failing because of a configuration failure and we created an upstream PR(https://github.com/openedx/edx-platform/pull/29403) and started running the tests on that specific branch so that our tests would pass.
- Now that the fix PR has been merged upstream I think we can get back to running our tests on master.

