### PR TITLE
Sysadmin-71 Creates course outline and sends course published signal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           cd ../edx-platform
           git remote add mitodl https://github.com/mitodl/edx-platform.git
           git fetch mitodl
-          git checkout mitodl/arslan/fix-pipeline-import
+          git checkout mitodl/master
 
       - name: Run tests
         run: |

--- a/edx_sysadmin/apps.py
+++ b/edx_sysadmin/apps.py
@@ -17,18 +17,11 @@ class EdxSysAdminConfig(AppConfig):
             "lms.djangoapp": {
                 "namespace": "sysadmin",
                 "regex": "^sysadmin/",
-            },
-            "cms.djangoapp": {
-                "namespace": "sysadmin",
-                "regex": "^sysadmin/",
-            },
+            }
         },
         "settings_config": {
             "lms.djangoapp": {
                 "common": {"relative_path": "settings.common"},
-            },
-            "cms.djangoapp": {
-                "common": {"relative_path": "settings.common"},
-            },
+            }
         },
     }

--- a/edx_sysadmin/apps.py
+++ b/edx_sysadmin/apps.py
@@ -17,11 +17,18 @@ class EdxSysAdminConfig(AppConfig):
             "lms.djangoapp": {
                 "namespace": "sysadmin",
                 "regex": "^sysadmin/",
-            }
+            },
+            "cms.djangoapp": {
+                "namespace": "sysadmin",
+                "regex": "^sysadmin/",
+            },
         },
         "settings_config": {
             "lms.djangoapp": {
                 "common": {"relative_path": "settings.common"},
-            }
+            },
+            "cms.djangoapp": {
+                "common": {"relative_path": "settings.common"},
+            },
         },
     }

--- a/edx_sysadmin/git_import.py
+++ b/edx_sysadmin/git_import.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import subprocess
+from io import StringIO
 
 from celery import shared_task
 from cms.djangoapps.contentstore.outlines import update_outline_from_modulestore
@@ -17,7 +18,6 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from opaque_keys.edx.locator import CourseLocator
-from six import StringIO
 from xmodule.modulestore.django import SignalHandler
 from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
 

--- a/edx_sysadmin/git_import.py
+++ b/edx_sysadmin/git_import.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 
 from celery import shared_task
+from cms.djangoapps.contentstore.outlines import update_outline_from_modulestore
 from django.conf import settings
 from django.core import management
 from django.core.management.base import CommandError
@@ -17,17 +18,11 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from opaque_keys.edx.locator import CourseLocator
 from six import StringIO
-
-from cms.djangoapps.contentstore.outlines import update_outline_from_modulestore
-from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
 from xmodule.modulestore.django import SignalHandler
+from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
 
 from edx_sysadmin.models import CourseGitLog
-from edx_sysadmin.utils.utils import (
-    remove_old_course_import_logs,
-    DEFAULT_GIT_REPO_PREFIX,
-)
-
+from edx_sysadmin.utils.utils import DEFAULT_GIT_REPO_PREFIX, remove_old_course_import_logs
 
 log = logging.getLogger(__name__)
 

--- a/edx_sysadmin/git_import.py
+++ b/edx_sysadmin/git_import.py
@@ -22,7 +22,10 @@ from xmodule.modulestore.django import SignalHandler
 from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
 
 from edx_sysadmin.models import CourseGitLog
-from edx_sysadmin.utils.utils import DEFAULT_GIT_REPO_PREFIX, remove_old_course_import_logs
+from edx_sysadmin.utils.utils import (
+    DEFAULT_GIT_REPO_PREFIX,
+    remove_old_course_import_logs,
+)
 
 log = logging.getLogger(__name__)
 

--- a/edx_sysadmin/git_import.py
+++ b/edx_sysadmin/git_import.py
@@ -2,7 +2,7 @@
 Provides a function for importing a git repository into the lms
 instance when using a mongo modulestore
 """
-
+# pylint: disable=wrong-import-order
 
 import logging
 import os

--- a/edx_sysadmin/git_import.py
+++ b/edx_sysadmin/git_import.py
@@ -18,7 +18,9 @@ from django.utils.translation import gettext_lazy as _
 from opaque_keys.edx.locator import CourseLocator
 from six import StringIO
 
+from cms.djangoapps.contentstore.outlines import update_outline_from_modulestore
 from xmodule.util.sandboxing import DEFAULT_PYTHON_LIB_FILENAME
+from xmodule.modulestore.django import SignalHandler
 
 from edx_sysadmin.models import CourseGitLog
 from edx_sysadmin.utils.utils import (
@@ -366,6 +368,10 @@ def add_repo(repo, rdir_in=None, branch=None):
         # We want set course id in CourseGitLog as CourseLocator. So that in split module
         # environment course id remain consistent as CourseLocator instance.
         course_key = CourseLocator(*course_id)
+        update_outline_from_modulestore(course_key)
+        SignalHandler.course_published.send(
+            sender=course_key.course, course_key=course_key
+        )
         cdir = "{0}/{1}".format(git_repo_dir, course_key.course)
         log.debug("Studio course dir = %s", cdir)
 

--- a/edx_sysadmin/management/commands/git_add_course.py
+++ b/edx_sysadmin/management/commands/git_add_course.py
@@ -6,12 +6,10 @@ import logging
 
 from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext as _
-
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.xml import XMLModuleStore
 
 from edx_sysadmin import git_import
-
 
 log = logging.getLogger(__name__)
 

--- a/edx_sysadmin/management/commands/git_add_course.py
+++ b/edx_sysadmin/management/commands/git_add_course.py
@@ -1,6 +1,7 @@
 """
 Script for importing courseware from git/xml into a mongo modulestore
 """
+# pylint: disable=wrong-import-order
 
 import logging
 

--- a/edx_sysadmin/management/commands/tests/test_git_add_course.py
+++ b/edx_sysadmin/management/commands/tests/test_git_add_course.py
@@ -7,14 +7,12 @@ import shutil
 import subprocess
 from uuid import uuid4
 
+import six
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.test.utils import override_settings
-from opaque_keys.edx.keys import CourseKey
-import six
 from six import StringIO
-
 from xmodule.modulestore import ModuleStoreEnum
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
@@ -38,16 +36,17 @@ class TestGitAddCourse(SharedModuleStoreTestCase):
     Tests the git_add_course management command for proper functions.
     """
 
-    TEST_REPO = "https://github.com/edx/edx4edx_lite.git"
-    TEST_COURSE = "MITx/edx4edx/edx4edx"
-    TEST_BRANCH = "testing_do_not_delete"
-    TEST_BRANCH_COURSE = CourseKey.from_string("MITx/edx4edx_branch/edx4edx")
-
     ENABLED_CACHES = ["default", "mongo_metadata_inheritance", "loc_cache"]
 
     def setUp(self):
         super().setUp()
         self.git_repo_dir = settings.GIT_REPO_DIR
+        self.TEST_REPO = "https://github.com/edx/edx4edx_lite.git"
+        self.TEST_COURSE = self.store.make_course_key("MITx", "edx4edx", "edx4edx")
+        self.TEST_BRANCH = "testing_do_not_delete"
+        self.TEST_BRANCH_COURSE = self.store.make_course_key(
+            "MITx", "edx4edx_branch", "edx4edx"
+        )
 
     def assertCommandFailureRegexp(self, regex, *args):
         """
@@ -192,7 +191,7 @@ class TestGitAddCourse(SharedModuleStoreTestCase):
         self.assertIsNone(def_ms.get_course(self.TEST_BRANCH_COURSE))
         git_import.add_repo(self.TEST_REPO, repo_dir / "edx4edx_lite", "master")
         self.assertIsNone(def_ms.get_course(self.TEST_BRANCH_COURSE))
-        self.assertIsNotNone(def_ms.get_course(CourseKey.from_string(self.TEST_COURSE)))
+        self.assertIsNotNone(def_ms.get_course(self.TEST_COURSE))
 
     def test_branch_exceptions(self):
         """

--- a/edx_sysadmin/management/commands/tests/test_git_add_course.py
+++ b/edx_sysadmin/management/commands/tests/test_git_add_course.py
@@ -1,6 +1,7 @@
 """
 Provide tests for git_add_course management command.
 """
+# pylint: disable=wrong-import-order
 import logging
 import os
 import shutil

--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -3,10 +3,13 @@ Utility function defined here.
 """
 import json
 import logging
-import urllib.parse
 import os
-import requests
+import urllib.parse
 
+import requests
+from common.djangoapps.student.models import UserProfile
+from common.djangoapps.student.roles import CourseInstructorRole
+from common.djangoapps.util.password_policy_validators import normalize_password
 from django import forms
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -14,21 +17,12 @@ from django.http import Http404
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from django_countries import countries
-from git import Repo, InvalidGitRepositoryError, NoSuchPathError
-
-from common.djangoapps.student.models import UserProfile
-from common.djangoapps.student.roles import (
-    CourseInstructorRole,
-)
-from common.djangoapps.util.password_policy_validators import normalize_password
-from openedx.core.djangoapps.user_authn.toggles import (
-    is_require_third_party_auth_enabled,
-)
+from git import InvalidGitRepositoryError, NoSuchPathError, Repo
+from openedx.core.djangoapps.user_authn.toggles import is_require_third_party_auth_enabled
 from xmodule.modulestore.django import modulestore
 
 from edx_sysadmin.models import CourseGitLog
 from edx_sysadmin.utils.markup import HTML, Text
-
 
 User = get_user_model()
 logger = logging.getLogger(__name__)

--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -1,6 +1,7 @@
 """
 Utility function defined here.
 """
+# pylint: disable=wrong-import-order
 import json
 import logging
 import os

--- a/edx_sysadmin/utils/utils.py
+++ b/edx_sysadmin/utils/utils.py
@@ -18,7 +18,9 @@ from django.urls import reverse
 from django.utils.translation import gettext as _
 from django_countries import countries
 from git import InvalidGitRepositoryError, NoSuchPathError, Repo
-from openedx.core.djangoapps.user_authn.toggles import is_require_third_party_auth_enabled
+from openedx.core.djangoapps.user_authn.toggles import (
+    is_require_third_party_auth_enabled,
+)
 from xmodule.modulestore.django import modulestore
 
 from edx_sysadmin.models import CourseGitLog

--- a/edx_sysadmin/views.py
+++ b/edx_sysadmin/views.py
@@ -1,6 +1,7 @@
 """
 Views for the Open edX SysAdmin Plugin
 """
+# pylint: disable=wrong-import-order
 import logging
 from io import StringIO
 

--- a/edx_sysadmin/views.py
+++ b/edx_sysadmin/views.py
@@ -4,26 +4,25 @@ Views for the Open edX SysAdmin Plugin
 import logging
 from io import StringIO
 
+from common.djangoapps.student.roles import CourseInstructorRole
 from django.contrib.auth.decorators import user_passes_test
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import Http404
 from django.shortcuts import render
+from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.html import escape
 from django.utils.translation import gettext as _
-from django.urls import reverse
 from django.views.decorators.cache import cache_control
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import condition
-from django.views.generic.base import TemplateView, RedirectView
-
+from django.views.generic.base import RedirectView, TemplateView
 from opaque_keys.edx.keys import CourseKey
-from common.djangoapps.student.roles import CourseInstructorRole
 from xmodule.modulestore.django import modulestore
 
-from edx_sysadmin.git_import import GitImportError
 from edx_sysadmin import git_import
 from edx_sysadmin.forms import UserRegistrationForm
+from edx_sysadmin.git_import import GitImportError
 from edx_sysadmin.models import CourseGitLog
 from edx_sysadmin.utils.markup import HTML, Text
 from edx_sysadmin.utils.utils import (
@@ -31,13 +30,12 @@ from edx_sysadmin.utils.utils import (
     get_course_by_id,
     get_registration_required_extra_fields_with_values,
     is_registration_api_functional,
-    user_has_access_to_users_panel,
     user_has_access_to_courses_panel,
-    user_has_access_to_git_logs_panel,
     user_has_access_to_git_import_panel,
+    user_has_access_to_git_logs_panel,
     user_has_access_to_sysadmin,
+    user_has_access_to_users_panel,
 )
-
 
 log = logging.getLogger(__name__)
 

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -28,22 +28,14 @@ set +e
 # We're running pycodestyle directly here since pytest-pep8 hasn't been updated in a while and has a bug
 # linting this project's code. pylint is also run directly since it seems cleaner to run them both
 # separately than to run one as a plugin and one by itself.
-echo "Running tests"
-pytest
-PYTEST_SUCCESS=$?
 echo "Running pycodestyle"
 pycodestyle edx_sysadmin tests
 PYCODESTYLE_SUCCESS=$?
-echo "Running pylint"
 
+echo "Running pylint"
 (cd /edx/app/edxapp/edx-platform; pylint /edx-sysadmin/edx_sysadmin)
 PYLINT_SUCCESS=$?
 
-if [[ $PYTEST_SUCCESS -ne 0 ]]
-then
-    echo "pytest exited with a non-zero status"
-    exit $PYTEST_SUCCESS
-fi
 if [[ $PYCODESTYLE_SUCCESS -ne 0 ]]
 then
     echo "pycodestyle exited with a non-zero status"
@@ -53,6 +45,16 @@ if [[ $PYLINT_SUCCESS -ne 0 ]]
 then
     echo "pylint exited with a non-zero status"
     exit $PYLINT_SUCCESS
+fi
+
+echo "Running tests"
+pytest
+PYTEST_SUCCESS=$?
+
+if [[ $PYTEST_SUCCESS -ne 0 ]]
+then
+    echo "pytest exited with a non-zero status"
+    exit $PYTEST_SUCCESS
 fi
 
 set -e

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,9 @@ setup(
         "lms.djangoapp": [
             "edx_sysadmin = edx_sysadmin.apps:EdxSysAdminConfig",
         ],
-        "cms.djangoapp": [],
+        "cms.djangoapp": [
+            "edx_sysadmin = edx_sysadmin.apps:EdxSysAdminConfig",
+        ],
     },
 )
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/edx-sysadmin/issues/71

#### What's this PR do?

- Creates course outline after course import success.
- Sends `course_published` signal to update the cache.

#### How should this be manually tested?

- Setup sysadmin using the [readme](https://github.com/mitodl/edx-sysadmin).
- Import a course using sysadmin. You can test one of the following:
   - https://github.com/mitodl/demo-test-course.git
   - https://github.com/mitocw/edx4edx_lite.git (Make a fork and clone then update grading policy)
   - NOTE: edx4edx has a few grading issues. Can be fixed using the below configs for midterm and final.
```
    {
      "type" : "Midterm",
      "name" : "Midterm Exam",
      "short_label" : "Midterm",
      "min_count": 1,
      "drop_count" : 0,
      "weight" : 0.3
    },
    {
      "type" : "Final",
      "name" : "Final Exam",
      "short_label" : "Final",
      "min_count": 1,
      "drop_count" : 0,
      "weight" : 0.4
    }
```
- After the course import success, Visit the course home page. The course outline is working fine.
- Now, Add a new chapter in the cloned git repo.
- Import the course from sysadmin.
- Visit the course home. The new chapter is visible in the course outline.
